### PR TITLE
Move moto dependency back to dev group

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -31,5 +31,8 @@ jobs:
       - name: Install Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Install the project
+        run: uv sync --dev
+
       - name: Run Pytest
         run: uv run pytest

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -31,8 +31,5 @@ jobs:
       - name: Install Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
-      - name: Install the project
-        run: uv sync --dev
-
       - name: Run Pytest
         run: uv run pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Ruff linting and formatting.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.8
+    rev: v0.12.9
     hooks:
       - id: ruff
         name: ruff check

--- a/object_storage/pyproject.toml
+++ b/object_storage/pyproject.toml
@@ -6,7 +6,6 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "boto3>=1.40.9",
-    "moto>=5.1.10",
     "pydantic>=2.11.7",
 ]
 
@@ -14,8 +13,7 @@ dependencies = [
 requires = ["uv_build>=0.8.0,<0.9"]
 build-backend = "uv_build"
 
-# TODO: figure out how to get CI to install the dev dependencies and remove moto above
-# [dependency-groups]
-# dev = [
-#     "moto>=5.1.10",
-# ]
+[dependency-groups]
+dev = [
+    "moto>=5.1.10",
+]

--- a/object_storage/pyproject.toml
+++ b/object_storage/pyproject.toml
@@ -12,8 +12,3 @@ dependencies = [
 [build-system]
 requires = ["uv_build>=0.8.0,<0.9"]
 build-backend = "uv_build"
-
-[dependency-groups]
-dev = [
-    "moto>=5.1.10",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = ["object_storage"]
 
 [dependency-groups]
 dev = [
+    "moto>=5.1.10",
     "pytest>=8.4.1",
     "ruff>=0.12.8",
     "ty>=0.0.1a17",

--- a/uv.lock
+++ b/uv.lock
@@ -301,16 +301,22 @@ version = "0.1.0"
 source = { editable = "object_storage" }
 dependencies = [
     { name = "boto3" },
-    { name = "moto" },
     { name = "pydantic" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "moto" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.9" },
-    { name = "moto", specifier = ">=5.1.10" },
     { name = "pydantic", specifier = ">=2.11.7" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "moto", specifier = ">=5.1.10" }]
 
 [[package]]
 name = "packaging"

--- a/uv.lock
+++ b/uv.lock
@@ -183,6 +183,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "moto" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
@@ -193,6 +194,7 @@ requires-dist = [{ name = "object-storage", editable = "object_storage" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "moto", specifier = ">=5.1.10" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "ruff", specifier = ">=0.12.8" },
     { name = "ty", specifier = ">=0.0.1a17" },
@@ -304,19 +306,11 @@ dependencies = [
     { name = "pydantic" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "moto" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.9" },
     { name = "pydantic", specifier = ">=2.11.7" },
 ]
-
-[package.metadata.requires-dev]
-dev = [{ name = "moto", specifier = ">=5.1.10" }]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Package(s)

`object_storage`

## Description

Move the `moto` dependency back to the `dev` group and out of the main dependencies of the package.

Gemini indicates that dev dependencies should always be defined at the root project level and not be added per package.

## Test plan

Updated GitHub actions to install dev dependencies before running unit tests.