### PR TITLE
Use importlib pytest option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ object_storage = { workspace = true }
 members = ["object_storage", "geometry"]
 
 [tool.pytest.ini_options]
+addopts = ["--import-mode=importlib"]
 filterwarnings = [
     # Somehow ShapelyDeprecationWarning causes an error without this line
     "ignore::DeprecationWarning:shapely",


### PR DESCRIPTION
## Package(s)

na

## Description

Running `uv run pytest` failed because the default import method did not allow multiple `test` directories (I think). Adding the option `--import-mode=importlib` fixed the failing tests in my previous PR. I found the solution here, https://docs.pytest.org/en/stable/explanation/pythonpath.html. 

The error I was getting before adding this looked like the following:

```shell
❯ uv run pytest object_storage
      Built object-storage @ file:///Users/mitchellgritts/dev/geografir/object_storage
Uninstalled 1 package in 1ms
Installed 1 package in 1ms
=================================================== test session starts ===================================================
platform darwin -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/mitchellgritts/dev/geografir
configfile: pyproject.toml
collected 16 items

object_storage/tests/test_object_location.py .......                                                                [ 43%]
object_storage/tests/test_object_store.py .........                                                                 [100%]

=================================================== 16 passed in 1.20s ====================================================
❯ uv run pytest geometry
=================================================== test session starts ===================================================
platform darwin -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/mitchellgritts/dev/geografir
configfile: pyproject.toml
collected 31 items

geometry/tests/test_crs.py ..................                                                                       [ 58%]
geometry/tests/test_geometry.py .............                                                                       [100%]

=================================================== 31 passed in 0.37s ====================================================
❯ uv run pytest
=================================================== test session starts ===================================================
platform darwin -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/mitchellgritts/dev/geografir
configfile: pyproject.toml
collected 31 items / 2 errors

========================================================= ERRORS ==========================================================
______________________________ ERROR collecting object_storage/tests/test_object_location.py ______________________________
ImportError while importing test module '/Users/mitchellgritts/dev/geografir/object_storage/tests/test_object_location.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../.pyenv/versions/3.12.11/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   ModuleNotFoundError: No module named 'tests.test_object_location'
_______________________________ ERROR collecting object_storage/tests/test_object_store.py ________________________________
ImportError while importing test module '/Users/mitchellgritts/dev/geografir/object_storage/tests/test_object_store.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../.pyenv/versions/3.12.11/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   ModuleNotFoundError: No module named 'tests.test_object_store'
================================================= short test summary info =================================================
ERROR object_storage/tests/test_object_location.py
ERROR object_storage/tests/test_object_store.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
==================================================== 2 errors in 0.18s ====================================================
```

When running the test for each directory everything worked fine. However running on the entire project each this error occured. 

## Test plan

- Watch CI passes. 
- Locally, run `uv run pytest` and see that all 4 test suites run.