### PR TITLE
[geografir/geometry] Add BoundingBox class and tests -- GEN-20452

### DIFF
--- a/geometry/src/geometry/bounding_box.py
+++ b/geometry/src/geometry/bounding_box.py
@@ -2,9 +2,12 @@
 A bounding box of a geometry with CRS information.
 """
 
+from __future__ import annotations
 from pyproj import CRS
 
 from geometry.crs import ensure_crs
+
+from geometry.geometry import Geometry
 
 
 class BoundingBox:
@@ -35,3 +38,17 @@ class BoundingBox:
         self.maxx = maxx
         self.maxy = maxy
         self.crs = ensure_crs(crs)
+
+    @staticmethod
+    def from_geometry(geometry: Geometry) -> BoundingBox:
+        """Create a BoundingBox from a Geometry object.
+
+        Args:
+            geometry (Geometry): The geometry to create the bounding box from.
+
+        Returns:
+            BoundingBox: The bounding box of the geometry.
+        """
+        minx, miny, maxx, maxy = geometry.geometry.bounds
+
+        return BoundingBox(minx, miny, maxx, maxy, crs=geometry.crs)

--- a/geometry/src/geometry/bounding_box.py
+++ b/geometry/src/geometry/bounding_box.py
@@ -1,0 +1,37 @@
+"""
+A bounding box of a geometry with CRS information.
+"""
+
+from pyproj import CRS
+
+from geometry.crs import ensure_crs
+
+
+class BoundingBox:
+    """Represents the bounding box of a geometry with CRS information."""
+
+    minx: float
+    miny: float
+    maxx: float
+    maxy: float
+    crs: CRS | int | str
+
+    def __init__(
+        self, minx: float, miny: float, maxx: float, maxy: float, crs: CRS | int | str
+    ):
+        """Initialize a BoundingBox object.
+
+        Args:
+            minx (float): The minimum x-coordinate of the bounding box.
+            miny (float): The minimum y-coordinate of the bounding box.
+            maxx (float): The maximum x-coordinate of the bounding box.
+            maxy (float): The maximum y-coordinate of the bounding box.
+            crs (CRS | int | str): The coordinate reference system of the bounding
+                box. This will be handled by `pyproj.CRS.from_user_input`. Any value
+                accepted by `pyproj.CRS.from_user_input` is valid.
+        """
+        self.minx = minx
+        self.miny = miny
+        self.maxx = maxx
+        self.maxy = maxy
+        self.crs = ensure_crs(crs)

--- a/geometry/tests/test_bounding_box.py
+++ b/geometry/tests/test_bounding_box.py
@@ -1,0 +1,27 @@
+from geometry.bounding_box import BoundingBox
+
+import pytest
+
+from pyproj import CRS
+
+boundinb_box_init_params = [
+    (0, 0, 1, 1, 4326),
+    (1, 1, 2, 2, "EPSG:26910"),
+    (-1, -1, 0, 0, "epsg:4326"),
+    (0, 0, 0, 0, CRS.from_epsg(5070)),
+]
+
+
+@pytest.mark.parametrize(
+    "minx, miny, maxx, maxy, crs",
+    boundinb_box_init_params,
+    ids=["EPSG:4326", "EPSG:26910", "EPSG:4326", "EPSG:5070"],
+)
+def test_bounding_box_init(minx, miny, maxx, maxy, crs):
+    bbox = BoundingBox(minx, miny, maxx, maxy, crs)
+
+    assert bbox.minx == minx
+    assert bbox.miny == miny
+    assert bbox.maxx == maxx
+    assert bbox.maxy == maxy
+    assert isinstance(bbox.crs, CRS)


### PR DESCRIPTION
## Package(s)

`geografir/geometry`

## Description

Adds a basic implementation of `BoundingBox` from `vp-airflow`. I have only added the basic skeleton and helper function to create a bounding box from a `Geometry`. 

## Test plan

1. See CI pass
2. Run locally `uv run pytest`