### PR TITLE
[geografir/geometry] Add magic methods (dunder methods)

### DIFF
--- a/geometry/README.md
+++ b/geometry/README.md
@@ -29,14 +29,24 @@ from geometry.geometry import Geometry
 
 # Create geometries
 point = Geometry(sp.Point(5, 5), CRS.from_epsg(26910))
+#> Geometry(geometry=<POINT (5 5)>, crs='EPSG:26910')
 line = Geometry(sp.LineString([(0, 0), (2, 2), (10, 10)]), "epsg:4326")
+#> Geometry(geometry=<LINESTRING (0 0, 2 2, 10 10)>, crs='EPSG:4326')
 polygon = Geometry(sp.Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]), crs=5070)
+#> Geometry(geometry=<POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))>, crs='EPSG:5070')
 
 # Shapely operations on the geometry
-buffered_shape = sp.buffer(point.geometry, 10)
+buffered_shape = sp.buffer(point.geometry, 1)
 point_buffered = Geometry(buffered_shape, point.crs)
+#> Geometry(geometry=<POLYGON ((6 5, 5.981 4.805, 5.924 4.617, 5.831 4.444, 5.707 4.293, 5.556 4....>, crs='EPSG:26910')
 
 # BoundingBox
 from geometry.bounding_box import BoundingBox
+bbox = BoundingBox(0, 0, 1, 1, 5070)
+#> BoundingBox(minx=0, miny=0, maxx=1, maxy=1, crs='EPSG:5070')
+
+# from a geometry
+polygon = Geometry(sp.Polygon([(0, 0), (2, 0), (1, 1), (0, 2), (0, 0)]), crs=5070)
 polygon_bbox = BoundingBox.from_geometry(polygon)
+#> BoundingBox(minx=0.0, miny=0.0, maxx=2.0, maxy=2.0, crs='EPSG:5070')
 ```

--- a/geometry/README.md
+++ b/geometry/README.md
@@ -5,14 +5,38 @@ This package provides two classe for representing geospatial shapes: `Geometry` 
 - `Geometry` - is a wrapper around a `shapely` geometry with an added `crs` attribute.
 - `BoundingBox` - the `minx`, `miny`, `maxx`, and `maxy` of a `Geometry` with a `crs`.
 
+## Key Design Decisions
+
+1. Minimal Wrappers: The `Geometry` class is a simple wrapper around `shapely` geometries. Users should work directly with the `Geometry.geometry` object with `shapely`'s methods and reconstruct the `Geometry` as needed.
+2. Explicit CRS: Each class have an explicit, required CRS using `pyrpoj.CRS` objects.
+3. Immutability: Operations return a new object rather than modifying existing objects.
+
 ## Installation
 
-While under active development install directly from GitHub:
+While under active development install directly from GitHub using `uv`:
 
 ```shell
 uv add https://github.com/Vibrant-Planet/geografir.git#subdirectory=geometry
 ```
 
-## Usage
+## Basic Usage
 
-tbd
+```python
+import shapely as sp
+from pyproj import CRS
+
+from geometry.geometry import Geometry
+
+# Create geometries
+point = Geometry(sp.Point(5, 5), CRS.from_epsg(26910))
+line = Geometry(sp.LineString([(0, 0), (2, 2), (10, 10)]), "epsg:4326")
+polygon = Geometry(sp.Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]), crs=5070)
+
+# Shapely operations on the geometry
+buffered_shape = sp.buffer(point.geometry, 10)
+point_buffered = Geometry(buffered_shape, point.crs)
+
+# BoundingBox
+from geometry.bounding_box import BoundingBox
+polygon_bbox = BoundingBox.from_geometry(polygon)
+```

--- a/geometry/src/geometry/bounding_box.py
+++ b/geometry/src/geometry/bounding_box.py
@@ -4,6 +4,7 @@ A bounding box of a geometry with CRS information.
 
 from __future__ import annotations
 from pyproj import CRS
+from typing import Iterator
 
 from geometry.crs import ensure_crs
 
@@ -54,6 +55,9 @@ class BoundingBox:
         return BoundingBox(minx, miny, maxx, maxy, crs=geometry.crs)
 
     # Magic methods (dunder methods) ----------------------------------------------
+    def __iter__(self) -> Iterator[float]:
+        return iter((self.minx, self.miny, self.maxx, self.maxy))
+
     def __repr__(self) -> str:
         crs_repr = self.crs.to_string()
         return f"BoundingBox(minx={self.minx}, miny={self.miny}, maxx={self.maxx}, maxy={self.maxy}, crs='{crs_repr}')"

--- a/geometry/src/geometry/bounding_box.py
+++ b/geometry/src/geometry/bounding_box.py
@@ -12,7 +12,38 @@ from geometry.geometry import Geometry
 
 
 class BoundingBox:
-    """Represents the bounding box of a geometry with CRS information."""
+    """Represents the bounding box of a geometry with CRS information.
+
+    A bounding box defines the rectangular extent of a geometry using minimum
+    and maximum x and y coordinates, along with coordinate reference system (CRS)
+    information for proper spatial context.
+
+    Attributes:
+        minx (float): The minimum x-coordinate of the bounding box.
+        miny (float): The minimum y-coordinate of the bounding box.
+        maxx (float): The maximum x-coordinate of the bounding box.
+        maxy (float): The maximum y-coordinate of the bounding box.
+        crs (CRS): The coordinate reference system of the bounding box.
+
+    Examples:
+        Create a bounding box from coordinates:
+
+        >>> bbox = BoundingBox(-122.5, 37.7, -122.4, 37.8, "EPSG:4326")
+        >>> print(bbox)
+        BoundingBox(minx=-122.5, miny=37.7, maxx=-122.4, maxy=37.8, crs='EPSG:4326')
+
+        Convert to list for coordinate processing:
+
+        >>> coords = list(bbox)
+        >>> print(coords)
+        [-122.5, 37.7, -122.4, 37.8]
+
+        Unpack coordinates:
+
+        >>> minx, miny, maxx, maxy = bbox
+        >>> print(f"Width: {maxx - minx}, Height: {maxy - miny}")
+        Width: 0.1, Height: 0.1
+    """
 
     minx: float
     miny: float
@@ -48,7 +79,17 @@ class BoundingBox:
             geometry (Geometry): The geometry to create the bounding box from.
 
         Returns:
-            BoundingBox: The bounding box of the geometry.
+            BoundingBox: The bounding box of the geometry with the same CRS.
+
+        Examples:
+            Create bounding box from a point geometry:
+
+            >>> from geometry.geometry import Geometry
+            >>> from shapely.geometry import Point
+            >>> geom = Geometry(Point(-122.4, 37.8), crs="EPSG:4326")
+            >>> bbox = BoundingBox.from_geometry(geom)
+            >>> print(list(bbox))
+            [-122.4, 37.8, -122.4, 37.8]
         """
         minx, miny, maxx, maxy = geometry.geometry.bounds
 

--- a/geometry/src/geometry/bounding_box.py
+++ b/geometry/src/geometry/bounding_box.py
@@ -53,7 +53,7 @@ class BoundingBox:
 
         return BoundingBox(minx, miny, maxx, maxy, crs=geometry.crs)
 
-    # Magic methods (dunder methods)
+    # Magic methods (dunder methods) ----------------------------------------------
     def __repr__(self) -> str:
         crs_repr = self.crs.to_string()
         return f"BoundingBox(minx={self.minx}, miny={self.miny}, maxx={self.maxx}, maxy={self.maxy}, crs='{crs_repr}')"

--- a/geometry/src/geometry/bounding_box.py
+++ b/geometry/src/geometry/bounding_box.py
@@ -19,10 +19,10 @@ class BoundingBox:
     information for proper spatial context.
 
     Attributes:
-        minx (float): The minimum x-coordinate of the bounding box.
-        miny (float): The minimum y-coordinate of the bounding box.
-        maxx (float): The maximum x-coordinate of the bounding box.
-        maxy (float): The maximum y-coordinate of the bounding box.
+        minx (int | float): The minimum x-coordinate of the bounding box.
+        miny (int | float): The minimum y-coordinate of the bounding box.
+        maxx (int | float): The maximum x-coordinate of the bounding box.
+        maxy (int | float): The maximum y-coordinate of the bounding box.
         crs (CRS): The coordinate reference system of the bounding box.
 
     Examples:
@@ -45,22 +45,27 @@ class BoundingBox:
         Width: 0.1, Height: 0.1
     """
 
-    minx: float
-    miny: float
-    maxx: float
-    maxy: float
+    minx: int | float
+    miny: int | float
+    maxx: int | float
+    maxy: int | float
     crs: CRS | int | str
 
     def __init__(
-        self, minx: float, miny: float, maxx: float, maxy: float, crs: CRS | int | str
+        self,
+        minx: int | float,
+        miny: int | float,
+        maxx: int | float,
+        maxy: int | float,
+        crs: CRS | int | str,
     ):
         """Initialize a BoundingBox object.
 
         Args:
-            minx (float): The minimum x-coordinate of the bounding box.
-            miny (float): The minimum y-coordinate of the bounding box.
-            maxx (float): The maximum x-coordinate of the bounding box.
-            maxy (float): The maximum y-coordinate of the bounding box.
+            minx (int | float): The minimum x-coordinate of the bounding box.
+            miny (int | float): The minimum y-coordinate of the bounding box.
+            maxx (int | float): The maximum x-coordinate of the bounding box.
+            maxy (int | float): The maximum y-coordinate of the bounding box.
             crs (CRS | int | str): The coordinate reference system of the bounding
                 box. This will be handled by `pyproj.CRS.from_user_input`. Any value
                 accepted by `pyproj.CRS.from_user_input` is valid.
@@ -96,7 +101,7 @@ class BoundingBox:
         return BoundingBox(minx, miny, maxx, maxy, crs=geometry.crs)
 
     # Magic methods (dunder methods) ----------------------------------------------
-    def __iter__(self) -> Iterator[float]:
+    def __iter__(self) -> Iterator[int | float]:
         return iter((self.minx, self.miny, self.maxx, self.maxy))
 
     def __repr__(self) -> str:

--- a/geometry/src/geometry/bounding_box.py
+++ b/geometry/src/geometry/bounding_box.py
@@ -52,3 +52,8 @@ class BoundingBox:
         minx, miny, maxx, maxy = geometry.geometry.bounds
 
         return BoundingBox(minx, miny, maxx, maxy, crs=geometry.crs)
+
+    # Magic methods (dunder methods)
+    def __repr__(self) -> str:
+        crs_repr = self.crs.to_string()
+        return f"BoundingBox(minx={self.minx}, miny={self.miny}, maxx={self.maxx}, maxy={self.maxy}, crs='{crs_repr}')"

--- a/geometry/src/geometry/bounding_box.py
+++ b/geometry/src/geometry/bounding_box.py
@@ -1,5 +1,13 @@
-"""
-A bounding box of a geometry with CRS information.
+"""Bounding box implementation with coordinate reference system support.
+
+This module provides the BoundingBox class for representing rectangular extents
+of geometries with proper CRS (Coordinate Reference System) information. The
+BoundingBox class integrates with pyproj for CRS handling and can be created
+from geometry objects or coordinate values directly.
+
+Classes:
+    BoundingBox: A rectangular extent with CRS information that supports
+        iteration and conversion to coordinate lists.
 """
 
 from __future__ import annotations
@@ -102,8 +110,10 @@ class BoundingBox:
 
     # Magic methods (dunder methods) ----------------------------------------------
     def __iter__(self) -> Iterator[int | float]:
+        """Yield coordinates as [minx, miny, maxx, maxy]."""
         return iter((self.minx, self.miny, self.maxx, self.maxy))
 
     def __repr__(self) -> str:
+        """Return string representation of the BoundingBox."""
         crs_repr = self.crs.to_string()
         return f"BoundingBox(minx={self.minx}, miny={self.miny}, maxx={self.maxx}, maxy={self.maxy}, crs='{crs_repr}')"

--- a/geometry/src/geometry/geometry.py
+++ b/geometry/src/geometry/geometry.py
@@ -43,3 +43,8 @@ class Geometry:
 
         self.geometry = geometry
         self.crs = ensure_crs(crs)
+
+    # Magic methods (dunder methods) ----------------------------------------------
+    def __repr__(self) -> str:
+        crs_repr = self.crs.to_string()
+        return f"Geometry(geometry={self.geometry!r}, crs='{crs_repr}')"

--- a/geometry/src/geometry/geometry.py
+++ b/geometry/src/geometry/geometry.py
@@ -46,5 +46,6 @@ class Geometry:
 
     # Magic methods (dunder methods) ----------------------------------------------
     def __repr__(self) -> str:
+        """Return string representation of the BoundingBox."""
         crs_repr = self.crs.to_string()
         return f"Geometry(geometry={self.geometry!r}, crs='{crs_repr}')"

--- a/geometry/src/geometry/geometry.py
+++ b/geometry/src/geometry/geometry.py
@@ -1,5 +1,13 @@
-"""
-A simple geospatial geometry package wrapping Shapely geometries with CRS information.
+"""A simple geospatial geometry package wrapping Shapely geometries with CRS information.
+
+This module provides the Geometry class which combines Shapely's powerful geometry
+objects with coordinate reference system (CRS) information from pyproj. This enables
+proper geospatial operations including coordinate transformations and projections
+while maintaining the rich geometric capabilities of Shapely.
+
+Classes:
+    Geometry: A wrapper that combines Shapely geometries with CRS information
+        for geospatial operations and coordinate transformations.
 """
 
 from shapely.geometry.base import BaseGeometry
@@ -10,31 +18,71 @@ from geometry.crs import ensure_crs
 
 
 class Geometry:
-    """
-    A geospatial geometry wrapper that combines Shapely geometries with CRS information.
+    """A geospatial geometry wrapper that combines Shapely geometries with CRS information.
 
     This class wraps a Shapely BaseGeometry object and associates it with a coordinate
-    reference system (CRS) to enable geospatial operations like reprojection.
+    reference system (CRS) to enable geospatial operations like reprojection, coordinate
+    transformation, and proper spatial analysis. Full Shapely functionality is deferred to
+    the underlying Shapely geometry object.
 
     Attributes:
-        geometry: The underlying Shapely geometry object
-        crs: The coordinate reference system as a pyproj CRS object
+        geometry (BaseGeometry): The underlying Shapely geometry object (Point, LineString,
+            Polygon, etc.).
+        crs (CRS): The coordinate reference system as a pyproj CRS object.
+
+    Examples:
+        Create geometry from different Shapely objects:
+
+        >>> import shapely as sp
+        >>> from shapely.geometry import Point, LineString, Polygon
+        >>> from geometry.geometry import Geometry
+
+        Point geometry:
+        >>> point = Point(-73.9857, 40.7484)
+        >>> geom = Geometry(point, "EPSG:4326")
+        >>> print(f"Coordinates: {geom.geometry.x}, {geom.geometry.y}")
+        Coordinates: -73.9857, 40.7484
+
+        LineString geometry:
+        >>> line = LineString([(-74.0, 40.7), (-73.9, 40.8)])
+        >>> geom = Geometry(line, 4326)
+        >>> print(f"Length: {geom.geometry.length:.6f} degrees")
+        Length: 0.141421 degrees
+
+        Polygon geometry with UTM projection:
+        >>> coords = [(500000, 4000000), (600000, 4000000), (600000, 4100000), (500000, 4100000), (500000, 4000000)]
+        >>> polygon = Polygon(coords)
+        >>> geom = Geometry(polygon, "EPSG:32633")  # UTM Zone 33N
+        >>> print(f"Area: {geom.geometry.area} square meters")
+        Area: 10000000000.0 square meters
+
+        Use Shapely on the geometry:
+        >>> print(sp.get_coordinates(geom.geometry))
+        [[500000.0, 4000000.0], [600000.0, 4000000.0], [600000.0, 4100000.0], [500000.0, 4100000.0], [500000.0, 4000000.0]]
+
+        Access CRS information:
+        >>> print(geom.crs.to_string())
+        'EPSG:32633'
+        >>> print(geom.crs.is_projected)
+        True
     """
 
     geometry: BaseGeometry
     crs: CRS
 
-    def __init__(self, geometry, crs):
-        """
-        Initialize a Geometry object.
+    def __init__(self, geometry: BaseGeometry, crs: CRS | int | str):
+        """Initialize a Geometry object with a Shapely geometry and CRS.
 
         Args:
-            geometry: A Shapely geometry object
-            crs: Coordinate reference system. Can be a pyproj CRS or EPSG code.
+            geometry (BaseGeometry): A Shapely geometry object (Point, LineString,
+                Polygon, MultiPoint, MultiLineString, MultiPolygon, or GeometryCollection).
+            crs (CRS | int | str): Coordinate reference system. Can be a pyproj CRS
+                object, EPSG code as integer, or any string format accepted by
+                `pyproj.CRS.from_user_input()` (e.g., "EPSG:4326", "WGS84", proj4 string).
 
         Raises:
-            TypeError: If geometry is not a Shapely BaseGeometry
-            ValueError: If CRS cannot be parsed
+            TypeError: If geometry is not a Shapely BaseGeometry instance.
+            ValueError: If CRS cannot be parsed by pyproj.
         """
         if not isinstance(geometry, BaseGeometry):
             raise TypeError(

--- a/geometry/tests/test_bounding_box.py
+++ b/geometry/tests/test_bounding_box.py
@@ -90,3 +90,13 @@ def test_bounding_box_from_geometry(geom, crs):
 def test_bounding_box_repr():
     bbox = BoundingBox(0, 0, 1, 1, CRS.from_epsg(4326))
     assert repr(bbox) == "BoundingBox(minx=0, miny=0, maxx=1, maxy=1, crs='EPSG:4326')"
+
+    # a more complex CRS
+    crs = CRS.from_proj4(
+        "+proj=omerc +lat_0=-36 +lonc=147 +alpha=-54 +k=1 +x_0=0 +y_0=0 +gamma=0 +ellps=WGS84 +towgs84=0,0,0,0,0,0,0"
+    )
+    bbox = BoundingBox(0, 0, 1, 1, crs)
+    assert (
+        repr(bbox)
+        == "BoundingBox(minx=0, miny=0, maxx=1, maxy=1, crs='+proj=omerc +lat_0=-36 +lonc=147 +alpha=-54 +k=1 +x_0=0 +y_0=0 +gamma=0 +ellps=WGS84 +towgs84=0,0,0,0,0,0,0 +type=crs')"
+    )

--- a/geometry/tests/test_bounding_box.py
+++ b/geometry/tests/test_bounding_box.py
@@ -84,3 +84,9 @@ def test_bounding_box_from_geometry(geom, crs):
     assert bbox.maxy == sp.get_coordinates(geometry.geometry)[:, 1].max()
     assert bbox.crs == geometry.crs
     assert isinstance(bbox.crs, CRS)
+
+
+# Magic methods (dunder methods) tests --------------------------------------------
+def test_bounding_box_repr():
+    bbox = BoundingBox(0, 0, 1, 1, CRS.from_epsg(4326))
+    assert repr(bbox) == "BoundingBox(minx=0, miny=0, maxx=1, maxy=1, crs='EPSG:4326')"

--- a/geometry/tests/test_bounding_box.py
+++ b/geometry/tests/test_bounding_box.py
@@ -87,6 +87,16 @@ def test_bounding_box_from_geometry(geom, crs):
 
 
 # Magic methods (dunder methods) tests --------------------------------------------
+
+
+## __iter__ tests
+def test_bounding_box_iter():
+    bbox = BoundingBox(0, 0, 1, 1, CRS.from_epsg(4326))
+    assert list(bbox) == [0, 0, 1, 1]
+    assert tuple(bbox) == (0, 0, 1, 1)
+
+
+## __repr__ tests
 def test_bounding_box_repr():
     bbox = BoundingBox(0, 0, 1, 1, CRS.from_epsg(4326))
     assert repr(bbox) == "BoundingBox(minx=0, miny=0, maxx=1, maxy=1, crs='EPSG:4326')"

--- a/geometry/tests/test_geometry.py
+++ b/geometry/tests/test_geometry.py
@@ -93,3 +93,13 @@ def test_init_invalid_crs():
 def test_geometry_repr():
     geometry = Geometry(Point(1.1, 2.2), CRS.from_epsg(4326))
     assert repr(geometry) == "Geometry(geometry=<POINT (1.1 2.2)>, crs='EPSG:4326')"
+
+    # a more complex CRS
+    crs = CRS.from_proj4(
+        "+proj=omerc +lat_0=-36 +lonc=147 +alpha=-54 +k=1 +x_0=0 +y_0=0 +gamma=0 +ellps=WGS84 +towgs84=0,0,0,0,0,0,0"
+    )
+    geometry = Geometry(Point(1.1, 2.2), crs)
+    assert (
+        repr(geometry)
+        == "Geometry(geometry=<POINT (1.1 2.2)>, crs='+proj=omerc +lat_0=-36 +lonc=147 +alpha=-54 +k=1 +x_0=0 +y_0=0 +gamma=0 +ellps=WGS84 +towgs84=0,0,0,0,0,0,0 +type=crs')"
+    )

--- a/geometry/tests/test_geometry.py
+++ b/geometry/tests/test_geometry.py
@@ -87,3 +87,9 @@ def test_init_invalid_crs():
     pt = Point(1, 2)
     with pytest.raises(CRSError, match="Invalid target CRS specification"):
         Geometry(pt, "invalid_crs")
+
+
+# Magic methods (dunder methods) tests --------------------------------------------
+def test_geometry_repr():
+    geometry = Geometry(Point(1.1, 2.2), CRS.from_epsg(4326))
+    assert repr(geometry) == "Geometry(geometry=<POINT (1.1 2.2)>, crs='EPSG:4326')"


### PR DESCRIPTION
## Package(s)

`geografir/geometry`

## Description

A few additions and modifications:

1. `__repr__` method for each class for better printing and debugging of each class
2. `__iter__` method for `BoundingBox`. This allows things like `list(bbox)` that will return `[minx, miny, maxx, maxy]`
3. Improved docstrings, examples, and documentation in the README

## Test plan

1. Tests pass in CI
2. Run locally `uv run pytest -v`
