### PR TITLE
[geografir/geometry] Export Geometry and BoundingBox directly from geometry

### DIFF
--- a/geometry/README.md
+++ b/geometry/README.md
@@ -25,7 +25,7 @@ uv add https://github.com/Vibrant-Planet/geografir.git#subdirectory=geometry
 import shapely as sp
 from pyproj import CRS
 
-from geometry.geometry import Geometry
+from geometry import Geometry
 
 # Create geometries
 point = Geometry(sp.Point(5, 5), CRS.from_epsg(26910))
@@ -41,7 +41,7 @@ point_buffered = Geometry(buffered_shape, point.crs)
 #> Geometry(geometry=<POLYGON ((6 5, 5.981 4.805, 5.924 4.617, 5.831 4.444, 5.707 4.293, 5.556 4....>, crs='EPSG:26910')
 
 # BoundingBox
-from geometry.bounding_box import BoundingBox
+from geometry import BoundingBox
 bbox = BoundingBox(0, 0, 1, 1, 5070)
 #> BoundingBox(minx=0, miny=0, maxx=1, maxy=1, crs='EPSG:5070')
 

--- a/geometry/src/geometry/__init__.py
+++ b/geometry/src/geometry/__init__.py
@@ -1,0 +1,6 @@
+"""Geometry package for geospatial operations with CRS support."""
+
+from geometry.geometry import Geometry
+from geometry.bounding_box import BoundingBox
+
+__all__ = ["Geometry", "BoundingBox"]

--- a/geometry/src/geometry/bounding_box.py
+++ b/geometry/src/geometry/bounding_box.py
@@ -97,7 +97,7 @@ class BoundingBox:
         Examples:
             Create bounding box from a point geometry:
 
-            >>> from geometry.geometry import Geometry
+            >>> from geometry import Geometry
             >>> from shapely.geometry import Point
             >>> geom = Geometry(Point(-122.4, 37.8), crs="EPSG:4326")
             >>> bbox = BoundingBox.from_geometry(geom)

--- a/geometry/src/geometry/geometry.py
+++ b/geometry/src/geometry/geometry.py
@@ -34,8 +34,8 @@ class Geometry:
         Create geometry from different Shapely objects:
 
         >>> import shapely as sp
-        >>> from shapely.geometry import Point, LineString, Polygon
-        >>> from geometry.geometry import Geometry
+        >>> from shapely import Point, LineString, Polygon
+        >>> from geometry import Geometry
 
         Point geometry:
         >>> point = Point(-73.9857, 40.7484)

--- a/geometry/tests/test_bounding_box.py
+++ b/geometry/tests/test_bounding_box.py
@@ -4,7 +4,7 @@ import pytest
 import shapely as sp
 
 from pyproj import CRS
-from shapely.geometry import (
+from shapely import (
     GeometryCollection,
     LineString,
     MultiLineString,

--- a/geometry/tests/test_geometry.py
+++ b/geometry/tests/test_geometry.py
@@ -4,7 +4,7 @@ import pytest
 
 from pyproj import CRS
 from pyproj.exceptions import CRSError
-from shapely.geometry import (
+from shapely import (
     GeometryCollection,
     LineString,
     MultiLineString,


### PR DESCRIPTION
## Package(s)

[geografir/geometry]

## Description

Prior to this change we needed to do this to import either class:

```python
from geometry.geometry import Geometry
from geometry.bounding_box import BoundingBox
```

Modifying the `__init__.py` to include these imports allows us to do the following instead which is a nice quality of life change.

```python
from geometry import Geometry, BoundingBox
```

I still recommend importing directly from the individual files when developing `geografir/geometry`.

I mostly copied how `shapely` has exported their modules in the `__init__.py`. 

## Test plan

Run the tests (or watch in CI)

Testing locally, try below after running `uv sync --dev && uv run python`


```python
from geometry import Geometry, BoundingBox

bbox = BoundingBox(0, 0, 1, 1, 5070)
```