### PR TITLE
[geografir/raster_array] RasterMetadata.copy, RasterMetadata.from_profile -- GEN-20596

### DIFF
--- a/raster_array/src/raster_array/exceptions.py
+++ b/raster_array/src/raster_array/exceptions.py
@@ -1,0 +1,2 @@
+class RasterArrayShapeError(Exception):
+    """Used when a RasterArray is not the correct/expected shape."""

--- a/raster_array/src/raster_array/raster_array.py
+++ b/raster_array/src/raster_array/raster_array.py
@@ -20,6 +20,7 @@ class RasterArray:
 
     def __init__(self, array: NDArray, metadata: RasterMetadata):
         _validate_3d_array(array)
+        _validate_array_shape_matches_metadata_shape(array, metadata)
 
         self.array = array
         self.metadata = metadata
@@ -33,4 +34,14 @@ class RasterArray:
 def _validate_3d_array(array: NDArray):
     if array.ndim != 3:
         msg = f"Array must have 3 dimensions, has {array.ndim}"
+        raise RasterArrayShapeError(msg)
+
+
+def _validate_array_shape_matches_metadata_shape(
+    array: NDArray, metadata: RasterMetadata
+):
+    if array.shape != metadata.shape:
+        msg = (
+            f"Array shape {array.shape} does not match metadata shape {metadata.shape}"
+        )
         raise RasterArrayShapeError(msg)

--- a/raster_array/src/raster_array/raster_array.py
+++ b/raster_array/src/raster_array/raster_array.py
@@ -1,0 +1,36 @@
+from numpy.typing import NDArray
+
+from raster_array.exceptions import RasterArrayShapeError
+from raster_array.raster_metadata import RasterMetadata
+
+
+class RasterArray:
+    """A spatially aware NDArray with raster metadata.
+
+    This class wraps the functionality of numpy.ndarray by adding raster metadata,
+    allowing for geospatial operations and interoperability with rasterio.
+
+    Attributes:
+        array (NDArray): The underlying numpy array storing the raster data.
+        metadata (RasterMetadata): Metadata describing the raster dataset.
+    """
+
+    array: NDArray
+    metadata: RasterMetadata
+
+    def __init__(self, array: NDArray, metadata: RasterMetadata):
+        _validate_3d_array(array)
+
+        self.array = array
+        self.metadata = metadata
+
+    # properties ------------------------------------------------------------------
+    # methods ---------------------------------------------------------------------
+    # magic methods (dunder methods) ----------------------------------------------
+
+
+# private helpers --------------------------------------------------------------
+def _validate_3d_array(array: NDArray):
+    if array.ndim != 3:
+        msg = f"Array must have 3 dimensions, has {array.ndim}"
+        raise RasterArrayShapeError(msg)

--- a/raster_array/src/raster_array/raster_metadata.py
+++ b/raster_array/src/raster_array/raster_metadata.py
@@ -112,12 +112,20 @@ class RasterMetadata:
 
     @property
     def bounds(self) -> tuple[float, float, float, float]:
-        """Return the bounds of the raster."""
+        """Return the bounds of the raster.
+
+        Returns:
+            tuple[float, float, float, float]: Bounding box as (left, bottom, right, top).
+        """
         return array_bounds(self.width, self.height, self.transform)
 
     @property
     def profile(self) -> Profile:
-        """Return a raster profile."""
+        """Return a raster profile.
+
+        Returns:
+            Profile: Rasterio profile with GeoTIFF settings applied.
+        """
         profile_fields = [
             "crs",
             "count",
@@ -133,25 +141,35 @@ class RasterMetadata:
 
     @property
     def shape(self) -> tuple[int, int, int]:
-        """Return the shape of the raster."""
+        """Return the shape of the raster.
+
+        Returns:
+            tuple[int, int, int]: Shape as (count, height, width).
+        """
         return (self.count, self.height, self.width)
 
     # methods ---------------------------------------------------------------------
     def copy(self, **kwargs) -> RasterMetadata:
-        """Create a copy of RasterMetadata.
+        """Create a copy of this RasterMetadata with optional modifications.
 
-        This is helpful when creating a copy RasterArray with some modifications to
-        the metadata without needing to specify every attribute. A lot of times we
-        need to change the dtype and nodata value but everything else stays the same.
+        This method creates a new RasterMetadata object with the same values as the
+        current one, but allows you to override specific attributes. This is useful
+        when you need to create a modified version without specifying all parameters.
 
         Args:
-            kwargs: any of the attributes of `RasterMetadata`. For example, `crs`, `count`,
-                `transform`.
+            **kwargs: Keyword arguments for any RasterMetadata attributes to override.
+                Valid keys include: crs, count, width, height, dtype, nodata,
+                transform, and resolution. Invalid keys are ignored.
 
         Returns:
-            RasterMetadata: a copy of the current values of `RasterMetadata` merged with
-                any values provided from kwargs. Any values in kwargs that are not attributes
-                of `RasterMetadata` will be ignored.
+            RasterMetadata: A new RasterMetadata object with updated values.
+
+        Examples:
+            >>> # Create a copy with different dtype and nodata
+            >>> new_metadata = metadata.copy(dtype=np.int16, nodata=-32767)
+            >>>
+            >>> # Create a copy with different CRS
+            >>> reprojected = metadata.copy(crs=CRS.from_epsg(3857))
         """
         current_items = self.__dict__
         allowed_keys_in_kwargs = set(current_items.keys()) & set(kwargs.keys())
@@ -162,6 +180,14 @@ class RasterMetadata:
     # @staticmethods --------------------------------------------------------------
     @staticmethod
     def from_profile(profile: Profile) -> RasterMetadata:
+        """Create a RasterMetadata object from a rasterio profile.
+
+        Args:
+            profile (Profile): Rasterio profile containing raster metadata.
+
+        Returns:
+            RasterMetadata: New RasterMetadata object with values from the profile.
+        """
         profile_fields = [
             "crs",
             "count",

--- a/raster_array/src/raster_array/raster_metadata.py
+++ b/raster_array/src/raster_array/raster_metadata.py
@@ -136,6 +136,21 @@ class RasterMetadata:
         """Return the shape of the raster."""
         return (self.count, self.height, self.width)
 
+    # @staticmethods --------------------------------------------------------------
+    @staticmethod
+    def from_profile(profile: Profile) -> RasterMetadata:
+        profile_fields = [
+            "crs",
+            "count",
+            "dtype",
+            "nodata",
+            "width",
+            "height",
+            "transform",
+        ]
+        profile_values = itemgetter(*profile_fields)(profile)
+        return RasterMetadata(**dict(zip(profile_fields, profile_values)))  # ty: ignore
+
     # Magic methods (dunder methods) ----------------------------------------------
     def __repr__(self):
         """Return string representation of the RasterMetadata."""

--- a/raster_array/src/raster_array/raster_metadata.py
+++ b/raster_array/src/raster_array/raster_metadata.py
@@ -136,6 +136,29 @@ class RasterMetadata:
         """Return the shape of the raster."""
         return (self.count, self.height, self.width)
 
+    # methods ---------------------------------------------------------------------
+    def copy(self, **kwargs) -> RasterMetadata:
+        """Create a copy of RasterMetadata.
+
+        This is helpful when creating a copy RasterArray with some modifications to
+        the metadata without needing to specify every attribute. A lot of times we
+        need to change the dtype and nodata value but everything else stays the same.
+
+        Args:
+            kwargs: any of the attributes of `RasterMetadata`. For example, `crs`, `count`,
+                `transform`.
+
+        Returns:
+            RasterMetadata: a copy of the current values of `RasterMetadata` merged with
+                any values provided from kwargs. Any values in kwargs that are not attributes
+                of `RasterMetadata` will be ignored.
+        """
+        current_items = self.__dict__
+        allowed_keys_in_kwargs = set(current_items.keys()) & set(kwargs.keys())
+        new_items = {key: kwargs[key] for key in allowed_keys_in_kwargs}
+        merged_items = {**current_items, **new_items}
+        return RasterMetadata(**merged_items)  # ty: ignore
+
     # @staticmethods --------------------------------------------------------------
     @staticmethod
     def from_profile(profile: Profile) -> RasterMetadata:

--- a/raster_array/tests/test_raster_array.py
+++ b/raster_array/tests/test_raster_array.py
@@ -55,11 +55,14 @@ def test_raster_array_shape_error(raster_4_x_4_multiband):
     array = raster_4_x_4_multiband.read()
     metadata = RasterMetadata.from_profile(raster_4_x_4_multiband.profile)
 
-    # clip to 2d
-    array = array[0]
+    # clip array 2x3x3 without updating count in metadata
+    with pytest.raises(RasterArrayShapeError, match="does not match metadata shape"):
+        RasterArray(array[:, :3, :3], metadata)
+
+    # clip to 2d updating metadata
     metadata = metadata.copy(count=1)
 
     with pytest.raises(
         RasterArrayShapeError, match="Array must have 3 dimensions, has 2"
     ):
-        RasterArray(array, metadata)
+        RasterArray(array[0], metadata)

--- a/raster_array/tests/test_raster_array.py
+++ b/raster_array/tests/test_raster_array.py
@@ -1,0 +1,65 @@
+# type: ignore
+"""Tests for the RasterArray class."""
+
+import numpy as np
+import pytest
+import rasterio as rio
+
+
+from raster_array.exceptions import RasterArrayShapeError
+from raster_array.raster_metadata import RasterMetadata
+from raster_array.raster_array import RasterArray
+
+
+@pytest.fixture(scope="session")
+def raster_4_x_4_multiband():
+    shape = (2, 4, 4)
+    count, height, width = shape
+    n = count * height * width
+    array = np.arange(0, n).reshape(shape)
+
+    metadata = RasterMetadata(
+        crs=rio.CRS.from_epsg(4326),
+        count=count,
+        width=width,
+        height=height,
+        dtype=np.int32,
+        nodata=-9999,
+        transform=rio.transform.Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0),
+    )
+
+    with rio.io.MemoryFile() as memfile:
+        with memfile.open(**metadata.profile) as dataset:
+            dataset.write(array)
+        with memfile.open() as dataset:
+            yield dataset
+
+
+# test initialization of RasterArray ----------------------------------------------
+def test_raster_array_init(raster_4_x_4_multiband):
+    array = raster_4_x_4_multiband.read()
+    metadata = RasterMetadata.from_profile(raster_4_x_4_multiband.profile)
+    raster = RasterArray(array, metadata)
+
+    assert raster.array.shape == (2, 4, 4)
+    assert raster.metadata.shape == (2, 4, 4)
+    assert raster.metadata.crs == rio.CRS.from_epsg(4326)
+    assert raster.metadata.dtype == "int32"
+    assert raster.metadata.nodata == -9999
+    assert raster.metadata.transform == rio.transform.Affine(
+        1.0, 0.0, 0.0, 0.0, -1.0, 4.0
+    )
+
+
+def test_raster_array_shape_error(raster_4_x_4_multiband):
+    array = raster_4_x_4_multiband.read()
+    metadata = RasterMetadata.from_profile(raster_4_x_4_multiband.profile)
+
+    # clip to 2d
+    array = array[0]
+    metadata = metadata.copy(count=1)
+
+    with pytest.raises(
+        RasterArrayShapeError, match="Array must have 3 dimensions, has 2"
+    ):
+        RasterArray(array, metadata)

--- a/raster_array/tests/test_raster_metadata.py
+++ b/raster_array/tests/test_raster_metadata.py
@@ -260,6 +260,45 @@ def test_raster_metadata_from_profile():
     assert profile == metadata.profile
 
 
+# Methods tests -----------------------------------------------------------------
+def test_raster_metadata_copy():
+    metadata = RasterMetadata(
+        crs=rio.CRS.from_epsg(5070),
+        count=3,
+        width=3,
+        height=3,
+        dtype="float32",
+        nodata=0.0,
+        transform=rio.transform.Affine(5.0, 0.0, 0.0, 0.0, -5.0, 5.0),
+        resolution=5,
+    )
+    new_metadata = metadata.copy(nodata=-9999, count=4, band_tags={})
+
+    assert new_metadata.nodata == -9999
+    assert new_metadata.count == 4
+
+    all_parameters_changed_metadata = metadata.copy(
+        crs=rio.CRS.from_epsg(5070),
+        count=2,
+        width=5,
+        height=9,
+        dtype="int32",
+        nodata=99,
+        transform=rio.transform.Affine(15.0, 10.0, -10.0, 0.0, -15.0, 80.0),
+        resolution=10,
+    )
+
+    assert all_parameters_changed_metadata.crs == rio.CRS.from_epsg(5070)
+    assert all_parameters_changed_metadata.count == 2
+    assert all_parameters_changed_metadata.width == 5
+    assert all_parameters_changed_metadata.height == 9
+    assert all_parameters_changed_metadata.dtype == "int32"
+    assert all_parameters_changed_metadata.transform == rio.transform.Affine(
+        15.0, 10.0, -10.0, 0.0, -15.0, 80.0
+    )
+    assert all_parameters_changed_metadata.resolution == 10
+
+
 # Magic methods (dunder methods) tests --------------------------------------------
 def test_raster_metadata_repr():
     metadata = RasterMetadata(

--- a/raster_array/tests/test_raster_metadata.py
+++ b/raster_array/tests/test_raster_metadata.py
@@ -234,6 +234,32 @@ def test_raster_metadata_shape():
     assert metadata.shape == (1, 10, 10)
 
 
+# @staticmethods tests -----------------------------------------------------------------
+def test_raster_metadata_from_profile():
+    profile = rio.profiles.Profile(
+        {
+            "driver": "GTiff",
+            "interleave": "pixel",
+            "tiled": True,
+            "blockxsize": 512,
+            "blockysize": 512,
+            "nodata": 0,
+            "compress": Compression.deflate,
+            "crs": rio.CRS.from_epsg(3310),
+            "width": 1859,
+            "height": 1566,
+            "transform": rio.transform.Affine(5.0, 0.0, -47045.0, 0.0, -5.0, 142190.0),
+            "count": 2,
+            "dtype": np.uint8,
+            "zlevel": 9,
+            "bigtiff": "YES",
+        }
+    )
+    metadata = RasterMetadata.from_profile(profile)
+
+    assert profile == metadata.profile
+
+
 # Magic methods (dunder methods) tests --------------------------------------------
 def test_raster_metadata_repr():
     metadata = RasterMetadata(


### PR DESCRIPTION
## Package(s)

`geografir/raster_array`

## Description

This PR includes the `copy` and `from_profile` methods for the metadata. This pretty much closes out `RasterMetadata` for now. Once we have a baseline, `RasterArray` class we might add a `RasterMetadata.from_raster` method to create a profile from a file or datasetreader. For now these can be derived from the actual `datasetreader.profile` with `RasterMetadata.from_profile`

## Test plan

1. CI tests pass
2. Local tests pass
