### PR TITLE
[geografir/raster_array]: mask and masked properties

### DIFF
--- a/raster_array/src/raster_array/raster_array.py
+++ b/raster_array/src/raster_array/raster_array.py
@@ -39,13 +39,29 @@ class RasterArray:
         """Return a boolean mask array indicating which pixels are masked.
 
         Returns:
-            NDArray: a boolean array where True indicates a masked pixel.
+            NDArray: A boolean array where True indicates a masked pixel. The mask
+                is created with the `nodata` value in `RasterArray.metadata.nodata`.
         """
         return (
             np.isnan(self.array)
             if np.isnan(self.metadata.nodata)
             else self.array == self.metadata.nodata
         )
+
+    @property
+    def masked(self) -> np.ma.MaskedArray:
+        """Return a MaskedArray of the array.
+
+
+        Returns:
+            numpy.ma.MaskedArray: A `MaskedArray` of `RasterArray.array`. The mask
+                is created with the `nodata` value in `RasterArray.metadata.nodata`.
+        """
+        array = np.ma.MaskedArray(
+            data=self.array, mask=self.mask, fill_value=self.metadata.nodata
+        )
+
+        return array
 
     # methods ---------------------------------------------------------------------
     def band(self, index: int) -> NDArray:
@@ -58,13 +74,6 @@ class RasterArray:
             NDArray: a 3D array of the given band index.
         """
         return self.array[slice(index - 1, index), :, :]
-
-    def masked(self) -> np.ma.MaskedArray:
-        array = np.ma.MaskedArray(
-            data=self.array, mask=self.mask, fill_value=self.metadata.nodata
-        )
-
-        return array
 
     # static methods --------------------------------------------------------------
     @staticmethod

--- a/raster_array/src/raster_array/raster_array.py
+++ b/raster_array/src/raster_array/raster_array.py
@@ -59,6 +59,13 @@ class RasterArray:
         """
         return self.array[slice(index - 1, index), :, :]
 
+    def masked(self) -> np.ma.MaskedArray:
+        array = np.ma.MaskedArray(
+            data=self.array, mask=self.mask, fill_value=self.metadata.nodata
+        )
+
+        return array
+
     # static methods --------------------------------------------------------------
     @staticmethod
     def from_raster(

--- a/raster_array/src/raster_array/raster_array.py
+++ b/raster_array/src/raster_array/raster_array.py
@@ -64,7 +64,7 @@ class RasterArray:
         return array
 
     # methods ---------------------------------------------------------------------
-    def band(self, index: int) -> NDArray:
+    def band(self, band_index: int) -> NDArray:
         """Return the given raster band as a 3D numpy array.
 
         Args:
@@ -73,7 +73,18 @@ class RasterArray:
         Returns:
             NDArray: a 3D array of the given band index.
         """
-        return self.array[slice(index - 1, index), :, :]
+        return self.array[slice(band_index - 1, band_index), :, :]
+
+    def band_masked(self, band_index: int) -> np.ma.MaskedArray:
+        """Return the given raster band as a 3D numpy MaskedArray.
+
+        Args:
+            band_index (int): the band index, starting at 1 to match rasterio's band index
+
+        Returns:
+            np.ma.MaskedArray: a 3D MaskedArray of the given band index.
+        """
+        return self.masked[slice(band_index - 1, band_index), :, :]
 
     # static methods --------------------------------------------------------------
     @staticmethod

--- a/raster_array/src/raster_array/raster_array.py
+++ b/raster_array/src/raster_array/raster_array.py
@@ -34,7 +34,31 @@ class RasterArray:
         self.metadata = metadata
 
     # properties ------------------------------------------------------------------
+    @property
+    def mask(self) -> NDArray:
+        """Return a boolean mask array indicating which pixels are masked.
+
+        Returns:
+            NDArray: a boolean array where True indicates a masked pixel.
+        """
+        return (
+            np.isnan(self.array)
+            if np.isnan(self.metadata.nodata)
+            else self.array == self.metadata.nodata
+        )
+
     # methods ---------------------------------------------------------------------
+    def band(self, index: int) -> NDArray:
+        """Return the given raster band as a 3D numpy array.
+
+        Args:
+            band_index (int): the band index, starting at 1 to match rasterio's band index
+
+        Returns:
+            NDArray: a 3D array of the given band index.
+        """
+        return self.array[slice(index - 1, index), :, :]
+
     # static methods --------------------------------------------------------------
     @staticmethod
     def from_raster(
@@ -88,13 +112,6 @@ class RasterArray:
             transform=transform,
             nodata=out_nodata,
             dtype=out_dtype,
-        )
-
-        print(
-            f"src nodata: {src_metadata.nodata}, target nodata: {target_nodata}, out nodata: {out_nodata}"
-        )
-        print(
-            f"src dtype: {src_metadata.dtype}, target dtype: {target_dtype}, out dtype: {out_dtype}"
         )
 
         return RasterArray(data, metadata)

--- a/raster_array/tests/test_raster_array.py
+++ b/raster_array/tests/test_raster_array.py
@@ -109,12 +109,31 @@ def test_raster_array_mask():
 
 
 # METHODS
-# test RasterArray.band --------------------------------------------------------
+## RasterArray.band ------------------------------------------------------------
 def test_raster_array_band(raster_4_x_4_multiband):
     raster = RasterArray.from_raster(raster_4_x_4_multiband)
 
     assert np.array_equal(raster.band(1), np.arange(0, 16).reshape((1, 4, 4)))
     assert np.array_equal(raster.band(2), np.arange(16, 32).reshape((1, 4, 4)))
+
+
+## RasterArray.masked ----------------------------------------------------------
+def test_raster_array_masked():
+    mask = np.array([[[True, False], [False, True]], [[True, False], [False, True]]])
+
+    with generate_raster(
+        [[[-99, 1], [1, -99]], [[-99, 1], [1, -99]]], -99, np.int16
+    ) as src:
+        raster = RasterArray.from_raster(src)
+        assert np.array_equal(raster.mask, mask)
+
+    with generate_raster(
+        [[[np.nan, 1.0], [1.0, np.nan]], [[np.nan, 1.0], [1.0, np.nan]]],
+        np.nan,
+        np.float32,
+    ) as src:
+        raster = RasterArray.from_raster(src)
+        assert np.array_equal(raster.mask, mask, equal_nan=True)
 
 
 # test RasterArray.from_raster -------------------------------------------------

--- a/raster_array/tests/test_raster_array.py
+++ b/raster_array/tests/test_raster_array.py
@@ -88,7 +88,7 @@ def test_raster_array_dtype_error(raster_4_x_4_multiband):
         RasterArray(array, metadata)
 
 
-# PROPERTIES
+# PROPERTIES -------------------------------------------------------------------
 # RasterArray.mask -------------------------------------------------------------
 def test_raster_array_mask():
     mask = np.array([[[True, False], [False, True]], [[True, False], [False, True]]])
@@ -106,15 +106,6 @@ def test_raster_array_mask():
     ) as src:
         raster = RasterArray.from_raster(src)
         assert np.array_equal(raster.mask, mask)
-
-
-# METHODS
-## RasterArray.band ------------------------------------------------------------
-def test_raster_array_band(raster_4_x_4_multiband):
-    raster = RasterArray.from_raster(raster_4_x_4_multiband)
-
-    assert np.array_equal(raster.band(1), np.arange(0, 16).reshape((1, 4, 4)))
-    assert np.array_equal(raster.band(2), np.arange(16, 32).reshape((1, 4, 4)))
 
 
 ## RasterArray.masked ----------------------------------------------------------
@@ -144,7 +135,36 @@ def test_raster_array_masked():
         assert np.isnan(raster.masked.fill_value)
 
 
-# test RasterArray.from_raster -------------------------------------------------
+# METHODS ----------------------------------------------------------------------
+## RasterArray.band ------------------------------------------------------------
+def test_raster_array_band(raster_4_x_4_multiband):
+    raster = RasterArray.from_raster(raster_4_x_4_multiband)
+
+    assert np.array_equal(raster.band(1), np.arange(0, 16).reshape((1, 4, 4)))
+    assert np.array_equal(raster.band(2), np.arange(16, 32).reshape((1, 4, 4)))
+
+
+## RasterArray.band_masked ------------------------------------------------------------
+def test_raster_array_band_masked():
+    data = [[[-99, 1], [1, -99]], [[-99, 1], [1, -99]]]
+    with generate_raster(data, -99, np.int16) as src:
+        raster = RasterArray.from_raster(src)
+        band_1 = raster.band_masked(1)
+        band_2 = raster.band_masked(2)
+
+        assert isinstance(band_1, np.ma.MaskedArray)
+        assert np.array_equal(band_1.data, [[[-99, 1], [1, -99]]], equal_nan=True)
+        assert np.array_equal(band_1.mask, [[[True, False], [False, True]]])
+        assert band_1.fill_value == -99
+
+        assert isinstance(band_2, np.ma.MaskedArray)
+        assert np.array_equal(band_2.data, [[[-99, 1], [1, -99]]], equal_nan=True)
+        assert np.array_equal(band_2.mask, [[[True, False], [False, True]]])
+        assert band_2.fill_value == -99
+
+
+# STATICMETHODS ----------------------------------------------------------------
+## RasterArray.from_raster -----------------------------------------------------
 type_and_nodata_coercion_data = [
     # (data, src_nodata, target_nodata, src_dtype, target_dtype)
     ([[[0.0, 1.0], [1.0, 0.0]]], 0, -99, np.float32, np.int16),
@@ -185,7 +205,7 @@ def test_from_raster_simple_target_nodata_or_dtype_coercion(
             assert raster.metadata.nodata == target_nodata
 
 
-# test helpers -----------------------------------------------------------------
+# test helper methods ----------------------------------------------------------
 def test_ensure_valid_nodata():
     # coerce values if necessary
     assert ensure_valid_nodata(0, np.int16) == 0

--- a/raster_array/tests/test_raster_array.py
+++ b/raster_array/tests/test_raster_array.py
@@ -88,6 +88,35 @@ def test_raster_array_dtype_error(raster_4_x_4_multiband):
         RasterArray(array, metadata)
 
 
+# PROPERTIES
+# RasterArray.mask -------------------------------------------------------------
+def test_raster_array_mask():
+    mask = np.array([[[True, False], [False, True]], [[True, False], [False, True]]])
+
+    with generate_raster(
+        [[[-99, 1], [1, -99]], [[-99, 1], [1, -99]]], -99, np.int16
+    ) as src:
+        raster = RasterArray.from_raster(src)
+        assert np.array_equal(raster.mask, mask)
+
+    with generate_raster(
+        [[[np.nan, 1.0], [1.0, np.nan]], [[np.nan, 1.0], [1.0, np.nan]]],
+        np.nan,
+        np.float32,
+    ) as src:
+        raster = RasterArray.from_raster(src)
+        assert np.array_equal(raster.mask, mask)
+
+
+# METHODS
+# test RasterArray.band --------------------------------------------------------
+def test_raster_array_band(raster_4_x_4_multiband):
+    raster = RasterArray.from_raster(raster_4_x_4_multiband)
+
+    assert np.array_equal(raster.band(1), np.arange(0, 16).reshape((1, 4, 4)))
+    assert np.array_equal(raster.band(2), np.arange(16, 32).reshape((1, 4, 4)))
+
+
 # test RasterArray.from_raster -------------------------------------------------
 type_and_nodata_coercion_data = [
     # (data, src_nodata, target_nodata, src_dtype, target_dtype)

--- a/raster_array/tests/test_raster_array.py
+++ b/raster_array/tests/test_raster_array.py
@@ -121,19 +121,27 @@ def test_raster_array_band(raster_4_x_4_multiband):
 def test_raster_array_masked():
     mask = np.array([[[True, False], [False, True]], [[True, False], [False, True]]])
 
-    with generate_raster(
-        [[[-99, 1], [1, -99]], [[-99, 1], [1, -99]]], -99, np.int16
-    ) as src:
+    data = [[[-99, 1], [1, -99]], [[-99, 1], [1, -99]]]
+    with generate_raster(data, -99, np.int16) as src:
         raster = RasterArray.from_raster(src)
-        assert np.array_equal(raster.mask, mask)
 
+        assert isinstance(raster.masked, np.ma.MaskedArray)
+        assert np.array_equal(raster.masked.data, data, equal_nan=True)
+        assert np.array_equal(raster.masked.mask, mask)
+        assert raster.masked.fill_value == -99
+
+    data = [[[np.nan, 1.0], [1.0, np.nan]], [[np.nan, 1.0], [1.0, np.nan]]]
     with generate_raster(
-        [[[np.nan, 1.0], [1.0, np.nan]], [[np.nan, 1.0], [1.0, np.nan]]],
+        data,
         np.nan,
         np.float32,
     ) as src:
         raster = RasterArray.from_raster(src)
-        assert np.array_equal(raster.mask, mask, equal_nan=True)
+
+        assert isinstance(raster.masked, np.ma.MaskedArray)
+        assert np.array_equal(raster.masked.data, data, equal_nan=True)
+        assert np.array_equal(raster.masked.mask, mask)
+        assert np.isnan(raster.masked.fill_value)
 
 
 # test RasterArray.from_raster -------------------------------------------------


### PR DESCRIPTION
## Package(s)

`geografir/raster_array`

## Description

As part of my experiment with only handling `NDArray`s internally, and relying on the users to handle masked operations on their own, I've added two properties that will help. 

- `RasterArray.mask` - returns just the mask array, a boolean array created by using `RasterArray.metadata.nodata` value.
- `RasterArray.masked` - returns a `np.ma.MaskedArray` of `RasterArray.array`. The mask from `RasterArray.mask` is used as the mask. The fill value is the `RasterArray.metadata.nodata` value.
- `RasterArray.band` - a method that returns a band as an `NDArray`
- `RasterArray.band_masked` - a method that returns a band as an `np.ma.MaskedArray`

## Test plan

Tests run in CI