### PR TITLE
[geografir/geometry] add Geometry.to_crs

### DIFF
--- a/geometry/src/geometry/exceptions.py
+++ b/geometry/src/geometry/exceptions.py
@@ -1,0 +1,2 @@
+class TransformError(Exception):
+    """Used when a Geometry transform/reprojection fails."""

--- a/geometry/src/geometry/geometry.py
+++ b/geometry/src/geometry/geometry.py
@@ -122,7 +122,7 @@ class Geometry:
                 f"Cannot create transformation from {self.crs} to {target_crs}"
             ) from e
 
-        # then apply trasnform
+        # then apply transform
         transformed_geometry = ops.transform(transformer.transform, self.geometry)
         return Geometry(transformed_geometry, target_crs)
 

--- a/geometry/src/geometry/geometry.py
+++ b/geometry/src/geometry/geometry.py
@@ -10,10 +10,15 @@ Classes:
         for geospatial operations and coordinate transformations.
 """
 
+from __future__ import annotations
+
 from shapely.geometry.base import BaseGeometry
+from shapely import ops
 
 from pyproj import CRS
+from pyproj import Transformer
 
+from geometry.exceptions import TransformError
 from geometry.crs import ensure_crs
 
 
@@ -92,7 +97,36 @@ class Geometry:
         self.geometry = geometry
         self.crs = ensure_crs(crs)
 
-    # Magic methods (dunder methods) ----------------------------------------------
+    # Methods ------------------------------------------------------------------
+    def to_crs(self, crs: CRS | int | str) -> Geometry:
+        """Convert the geometry to a different coordinate reference system.
+
+        Args:
+            crs (CRS | int | str): Coordinate reference system. Can be a pyproj CRS
+                object, EPSG code as integer, or any string format accepted by
+                `pyproj.CRS.from_user_input()` (e.g., "EPSG:4326", "WGS84", proj4 string).
+
+        Returns:
+            Geometry: A new Geometry object with the converted geometry and CRS.
+        """
+        target_crs = ensure_crs(crs)
+
+        if self.crs.equals(target_crs):
+            return self
+
+        # create transform object (this can fail if transforming between incompatible projects, this should be rare)
+        try:
+            transformer = Transformer.from_crs(self.crs, target_crs, always_xy=True)
+        except Exception as e:
+            raise TransformError(
+                f"Cannot create transformation from {self.crs} to {target_crs}"
+            ) from e
+
+        # then apply trasnform
+        transformed_geometry = ops.transform(transformer.transform, self.geometry)
+        return Geometry(transformed_geometry, target_crs)
+
+    # Magic methods (dunder methods) -------------------------------------------
     def __repr__(self) -> str:
         """Return string representation of the BoundingBox."""
         crs_repr = self.crs.to_string()


### PR DESCRIPTION
## Package(s)

`geografir/geometry`

## Description

Adds method and tests for `Geometry.to_crs`. I imagine this function may cause some weirdness as we hit more edge cases. For example, we aren't trying to wrap the dateline at all. This is slightly complicated, and has slightly unclean implementations (dateline = -180/180 degrees in geographic CRS). I'm currently thinking about how to implement this, but it is not currently a requirement for us.

I may add similar functionality to `BoundingBox`, haven't decided yet. It currently exists in `vp-airflow` but we don't have a good use case yet.

## Test plan

Tests pass in CI
