### PR TITLE
[geografir/raster_array] Simplified to_raster method

### DIFF
--- a/raster_array/src/raster_array/raster_array.py
+++ b/raster_array/src/raster_array/raster_array.py
@@ -86,6 +86,28 @@ class RasterArray:
         """
         return self.masked[slice(band_index - 1, band_index), :, :]
 
+    def to_raster(self, filename: str) -> None:
+        """Save RasterArray as a Cloud Optimized GeoTIFF (COG).
+
+        The output GeoTIFF is a COG, but lacks overviews by default.
+
+        The alpha band is set to "UNSPECIFIED" so that an alpha band is not
+        automatically set. Four band int files are automatically created with RGBA set as the color interpretation,
+        which can result in issues with gdal computations when the last band is not actually an alpha band.
+
+        TODO:
+            - Handle overviews
+            - Handle COG driver properly
+
+        Args:
+            filename (str): Path to write the file.
+        """
+        write_params = self.metadata.profile
+        write_params["alpha"] = "UNSPECIFIED"
+
+        with rio.open(filename, "w", **write_params) as dst:
+            dst.write(self.array)
+
     # static methods --------------------------------------------------------------
     @staticmethod
     def from_raster(

--- a/raster_array/tests/test_raster_array.py
+++ b/raster_array/tests/test_raster_array.py
@@ -163,6 +163,16 @@ def test_raster_array_band_masked():
         assert band_2.fill_value == -99
 
 
+def test_raster_array_to_raster(raster_4_x_4_multiband, tmp_path):
+    raster = RasterArray.from_raster(raster_4_x_4_multiband)
+    out_path = tmp_path / "test.tiff"
+    raster.to_raster(out_path)
+
+    reread_raster = RasterArray.from_raster(out_path)
+
+    assert np.array_equal(raster.array, reread_raster.array)
+
+
 # STATICMETHODS ----------------------------------------------------------------
 ## RasterArray.from_raster -----------------------------------------------------
 type_and_nodata_coercion_data = [


### PR DESCRIPTION
## Package(s)

`geografir/raster_array`

## Description

A simplified version of `RasterArray.to_raster`. Compared to `vp-airflow` this does not handle overviews, band tags, etc. I've marked these as todo in the docstring.

## Test plan

Tests pass in CI