### PR TITLE
[geografir/raster_array] Add RasterArray.conform_to method

### DIFF
--- a/raster_array/src/raster_array/raster_array.py
+++ b/raster_array/src/raster_array/raster_array.py
@@ -132,15 +132,15 @@ class RasterArray:
         )
         merged_mask = np.logical_or(raster.mask, out_mask)
 
-        print("printing masks")
-        print("self.mask")
-        print(self.mask)
-        print("raster.mask")
-        print(raster.mask)
-        print("out_mask")
-        print(out_mask)
-        print("merged_mask")
-        print(merged_mask)
+        # print("printing masks")
+        # print("self.mask")
+        # print(self.mask)
+        # print("raster.mask")
+        # print(raster.mask)
+        # print("out_mask")
+        # print(out_mask)
+        # print("merged_mask")
+        # print(merged_mask)
 
         out_data[merged_mask] = out_meta.nodata
 

--- a/raster_array/src/raster_array/raster_array.py
+++ b/raster_array/src/raster_array/raster_array.py
@@ -91,14 +91,19 @@ class RasterArray:
     def conform_to(
         self,
         raster: RasterArray,
+        target_nodata: int | float | None = None,
+        target_dtype: DTypeLike | None = None,
         resampling: Resampling = Resampling.nearest,
     ) -> RasterArray:
         if not isinstance(raster, RasterArray):
             raise ValueError("raster must be of type RasterArray")
 
         # TODO: check that self and raster overlap, if not return self or raise
-        # TODO: overrides for dtype and nodata
+        nodata = target_nodata or self.metadata.nodata
+        dtype = target_dtype or self.metadata.dtype
         out_meta = self.metadata.copy(
+            nodata=nodata,
+            dtype=dtype,
             crs=raster.metadata.crs,
             height=raster.metadata.height,
             transform=raster.metadata.transform,

--- a/raster_array/tests/test_raster_array.py
+++ b/raster_array/tests/test_raster_array.py
@@ -409,6 +409,21 @@ def test_raster_array_conform_to_multiband_w_different_masks():
     assert conformed.metadata.dtype == src_raster.metadata.dtype
 
 
+def test_raster_array_conform_to_reprojects_resamples(raster_4326, raster_26910):
+    src_raster = raster_4326
+    ref_raster = raster_26910
+
+    conformed = src_raster.conform_to(ref_raster)
+
+    assert isinstance(conformed, RasterArray)
+    # conformed data is from the center of the src raster
+    assert conformed.array.min() > 20
+    assert conformed.array.max() < 80
+    assert conformed.metadata.crs.equals(ref_raster.metadata.crs)
+    assert conformed.metadata.width == ref_raster.metadata.width
+    assert conformed.metadata.height == ref_raster.metadata.height
+
+
 def test_raster_array_conform_to_override_nodata():
     src_data = np.array([[[1, 0], [0, 1]]], dtype=np.int16)
     ref_data = np.ones((1, 2, 2), dtype=np.uint8)
@@ -444,21 +459,6 @@ def test_raster_array_conform_to_override_dtype():
         conformed.array, np.array([[[1.0, 0.0], [0.0, 1.0]]], dtype=np.float32)
     )
     assert np.array_equal(conformed.mask, (src_data == 0))
-
-
-def test_raster_array_conform_to_reprojects_resamples(raster_4326, raster_26910):
-    src_raster = raster_4326
-    ref_raster = raster_26910
-
-    conformed = src_raster.conform_to(ref_raster)
-
-    assert isinstance(conformed, RasterArray)
-    # conformed data is from the center of the src raster
-    assert conformed.array.min() > 20
-    assert conformed.array.max() < 80
-    assert conformed.metadata.crs.equals(ref_raster.metadata.crs)
-    assert conformed.metadata.width == ref_raster.metadata.width
-    assert conformed.metadata.height == ref_raster.metadata.height
 
 
 ## RasterArray.to_raster -------------------------------------------------------

--- a/raster_array/tests/test_raster_array.py
+++ b/raster_array/tests/test_raster_array.py
@@ -456,6 +456,7 @@ def test_raster_array_conform_to_reprojects_resamples(raster_4326, raster_26910)
     # conformed data is from the center of the src raster
     assert conformed.array.min() > 20
     assert conformed.array.max() < 80
+    assert conformed.metadata.crs.equals(ref_raster.metadata.crs)
     assert conformed.metadata.width == ref_raster.metadata.width
     assert conformed.metadata.height == ref_raster.metadata.height
 


### PR DESCRIPTION
## Package(s)

`geografir/raster_array`

## Description

Adds the `RasterArray.conform_to` method. This is a slightly larger departure from the current implementation in `vp-airflow` than some of the others. Again, this is due to experimenting with `RasterArray` only handling `NDArrays` rather than `MaskeArrays`. This is intentional for now. I think the code is less complex and easier to reason about than when we had to handle masks in all of our raster operations. My philosophy going in was to defer all complex numpy operations to the user rather than trying to wrap complex logic, and dealing with the myriad edge cases. For example, how do you promote or demote a dtype when there is a dtype overflow? In `vp-airflow` we encoded business logic into `RasterArray` as it made sense for us in that context. However, across repos and use cases it's safer for the user to handle this prior to creating the `RasterArray`, or after by using the `RasterArray.array` and creating a new `RasterArray`.

I tried to write the tests so that they build in complexity. I first check that two different shaped arrays can be conformed. Then I start adding masks, different shapes, reprojection and resampling. This builds a foundation that shows the conform step works. Then when testing some of the override options I only need to worry about showing the overrides work as expected.

Here is an example output of the reproject and conform test. The bigger raster is the src raster in 4326. The smaller raster is the conformed raster (ref raster was in 26910 and a different resolution).

<img width="898" height="916" alt="image" src="https://github.com/user-attachments/assets/5ebacca2-b1a0-4b7c-b4c4-8ac301f4b1ea" />


## Test plan

CI tests pass