### PR TITLE
[geografir/raster_array] Read a single band with RasterArray.from_raster

### DIFF
--- a/raster_array/tests/test_raster_array.py
+++ b/raster_array/tests/test_raster_array.py
@@ -514,6 +514,18 @@ def test_from_raster_simple_target_nodata_or_dtype_coercion(
             assert raster.metadata.nodata == target_nodata
 
 
+def test_from_raster_band_index(raster_4_x_4_multiband):
+    all_bands = RasterArray.from_raster(raster_4_x_4_multiband, band_index=None)
+    band_1 = RasterArray.from_raster(raster_4_x_4_multiband, band_index=1)
+    band_2 = RasterArray.from_raster(raster_4_x_4_multiband, band_index=2)
+
+    assert np.array_equal(all_bands.array[0:1, :, :], band_1.array)
+    assert np.array_equal(all_bands.array[1:2, :, :], band_2.array)
+    assert all_bands.metadata.count == 2
+    assert band_1.metadata.count == 1
+    assert band_2.metadata.count == 1
+
+
 # test helper methods ----------------------------------------------------------
 def test_ensure_valid_nodata():
     # coerce values if necessary


### PR DESCRIPTION
## Package(s)

`geografir/raster_array`

## Description

Read individual bands from a raster with `RasterArray.from_raster` by providing an optional `band_index` parameter. This is passed to `rasterio.DatasetReader.read`, `indexes` parameter, which itself is optional, or accepts an integer or list of integers to read into memory. In this implementation I only an integer on `None` (default). 

If an integer is passed only that band is read into memory. I'm inserting this integer into a list as that will read the data into a 3d array instead of a 2d array. If passing a list of integers then `[[int]]` is passed into `rasterio.DatasetReader.read` which will raise an error. 

## Test plan

Tests pass in CI