### PR TITLE
[geografir/raster_array]: Allow band_index to be a list of indices in RasterArray.from_raster

### DIFF
--- a/raster_array/src/raster_array/raster_array.py
+++ b/raster_array/src/raster_array/raster_array.py
@@ -344,7 +344,7 @@ def ensure_band_index(band_index: int | list[int] | None) -> list[int] | None:
         return band_index
 
     if isinstance(band_index, int):
-        band_index = [band_index]
+        return [band_index]
 
     if type(band_index) is list:
         if len(band_index) > 0 and all(


### PR DESCRIPTION
## Package(s)

`geografir/raster_array`

## Description

A quick follow up to #30 to allow the `band_index` parameter in `RasterArray.from_raster` to be a list of integers to read a list of bands. This now checked in an `ensure_band_index` function that will type check and safely coerce an `int` if necessary. Tests included for both `ensure_band_index` and the new functionality to `RasterArray.from_raster`. 

## Test plan

CI tests pass