### PR TITLE
ObjectStorage.upload_directory takes recursive keyword argument [GEN-24029]

### DIFF
--- a/object_storage/src/object_storage/object_store.py
+++ b/object_storage/src/object_storage/object_store.py
@@ -318,7 +318,7 @@ class ObjectStore:
             >>> # Uploads /local/backup/file1.txt to s3://backup/daily/file1.txt
             >>> # Uploads /local/backup/file2.txt to s3://backup/daily/file2.txt
         """
-        # When topdwon=True the the tuple for the diretory is generated before
+        # When topdown=True the the tuple for the diretory is generated before
         # its subdirectories. This means local_directory is always first
         directory_tree = list(os.walk(local_directory, topdown=True))
         directory_tree = directory_tree if recursive else directory_tree[:1]

--- a/object_storage/src/object_storage/object_store.py
+++ b/object_storage/src/object_storage/object_store.py
@@ -289,6 +289,7 @@ class ObjectStore:
         self,
         object_location: ObjectLocation,
         local_directory: str,
+        recursive: bool = False,
     ) -> None:
         """Upload all files from a local directory to S3.
 
@@ -302,9 +303,12 @@ class ObjectStore:
                 Individual files will be stored with paths created by extending this
                 base location with each local filename.
             local_directory (str): The local directory containing files to upload.
-                Only immediate directory contents are processed; subdirectories are
-                not traversed recursively. All files in the directory must be readable
-                and will be uploaded to S3.
+                If recursive=False, only immediate directory contents are processed.
+                If recursive=True, all subdirectories are traversed and the directory
+                structure is preserved in S3.
+            recursive (bool, optional): If True crawl the local directory and upload
+                all files from any subdirectories. The directory structure will be
+                preserved in S3. Defaults to False.
 
         Examples:
             Upload directory contents:
@@ -314,7 +318,12 @@ class ObjectStore:
             >>> # Uploads /local/backup/file1.txt to s3://backup/daily/file1.txt
             >>> # Uploads /local/backup/file2.txt to s3://backup/daily/file2.txt
         """
-        for root, _, files in os.walk(local_directory):
+        # When topdwon=True the the tuple for the diretory is generated before
+        # its subdirectories. This means local_directory is always first
+        directory_tree = list(os.walk(local_directory, topdown=True))
+        directory_tree = directory_tree if recursive else directory_tree[:1]
+
+        for root, _dirs, files in directory_tree:
             for file in files:
                 local_path = os.path.join(root, file)
                 relative_path = str(os.path.relpath(local_path, local_directory))

--- a/object_storage/tests/test_object_store.py
+++ b/object_storage/tests/test_object_store.py
@@ -144,8 +144,7 @@ def test_upload_directory(s3):
                 f.write("upload me!")
 
         store.upload_directory(
-            object_location=upload_location,
-            local_directory=tmpdir,
+            object_location=upload_location, local_directory=tmpdir, recursive=True
         )
 
     uploaded_files = store.list_files(upload_location)
@@ -153,6 +152,33 @@ def test_upload_directory(s3):
 
     for location in uploaded_files:
         assert location.path in expected_files
+        assert len(uploaded_files) == 4
+
+
+def test_upload_directory_recursive_false(s3):
+    create_files(s3)
+    store = ObjectStore(s3_client=s3)
+
+    upload_location = ObjectLocation(bucket=TEST_BUCKET, path="uploads/")
+
+    files = ["upload1.txt", "upload2.txt", "subdir/upload3.txt", "subdir/upload4.txt"]
+    with TemporaryDirectory() as tmpdir:
+        os.mkdir(os.path.join(tmpdir, "subdir"))
+        for file in files:
+            filepath = os.path.join(tmpdir, file)
+            with open(filepath, "w") as f:
+                f.write("upload me!")
+
+        store.upload_directory(
+            object_location=upload_location, local_directory=tmpdir, recursive=False
+        )
+
+    uploaded_files = store.list_files(upload_location)
+    expected_files = ["uploads/upload1.txt", "uploads/upload2.txt"]
+
+    for location in uploaded_files:
+        assert location.path in expected_files
+        assert len(uploaded_files) == 2
 
 
 def test_remote_file_exists(s3):


### PR DESCRIPTION
## Package(s)

`object_storage`

## Description

- Added: keyword argument `recursive` to `ObjectStorage.upload_directory` with `False` as the default value.
- Added: additional test checking the `recursive=False` behavior` works as expected.
- Updated: docstring with new arguments details.

## Test plan

Tests should pass
